### PR TITLE
Support ROW DELETION POLICY

### DIFF
--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_table_statement.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_table_statement.java
@@ -80,6 +80,14 @@ public class ASTcreate_table_statement extends SimpleNode {
     }
   }
 
+    public synchronized Optional<ASTrow_deletion_policy_clause> getRowDeletionPolicyClause() {
+        try {
+            return Optional.of(ASTTreeUtils.getChildByType(children, ASTrow_deletion_policy_clause.class));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+
   public ASTcreate_table_statement clearConstraints() {
       this.withConstraints = false;
       return this;
@@ -109,6 +117,12 @@ public class ASTcreate_table_statement extends SimpleNode {
       ret.append(", ");
       ret.append(interleaveClause.get()); // interleave optional
     }
+
+    Optional<ASTrow_deletion_policy_clause> rowDeletionPolicyClause = getRowDeletionPolicyClause();
+    if (rowDeletionPolicyClause.isPresent()) {
+        ret.append(", ");
+        ret.append(rowDeletionPolicyClause.get());
+    }
     return ret.toString();
   }
 
@@ -120,6 +134,7 @@ public class ASTcreate_table_statement extends SimpleNode {
           && !(child instanceof ASTcheck_constraint)
           && !(child instanceof ASTprimary_key)
           && !(child instanceof ASTtable_interleave_clause)
+          && !(child instanceof ASTrow_deletion_policy_clause)
       ) {
         throw new IllegalArgumentException(
             "Unknown child type " + child.getClass().getSimpleName() + " - " + child);

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTinterval_expression.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTinterval_expression.java
@@ -1,0 +1,28 @@
+
+package com.google.cloud.solutions.spannerddl.parser;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.google.common.base.Joiner;
+import java.util.Arrays;
+
+
+/** Abstract Syntax Tree parser object for "interval_expression" token */
+public class ASTinterval_expression extends SimpleNode {
+    private static final Logger LOG = LoggerFactory.getLogger(ASTinterval_expression.class);
+
+    public ASTinterval_expression(int id) {
+        super(id);
+    }
+
+    public ASTinterval_expression(DdlParser p, int id) {
+        super(p, id);
+    }
+
+    @Override
+    public String toString() {
+        // eg INTERVAL num_days DAY
+        // Apparently only supports DAY
+        return "INTERVAL " + children[0] + " DAY";
+    }
+}

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTrow_deletion_policy_clause.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTrow_deletion_policy_clause.java
@@ -1,0 +1,28 @@
+
+package com.google.cloud.solutions.spannerddl.parser;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.google.common.base.Joiner;
+import java.util.Arrays;
+
+
+// TODO Support row deletion policy clause in ALTER statements
+/** Abstract Syntax Tree parser object for "row_deletion_policy_clause" token */
+public class ASTrow_deletion_policy_clause extends SimpleNode {
+    private static final Logger LOG = LoggerFactory.getLogger(ASTrow_deletion_policy_clause.class);
+
+    public ASTrow_deletion_policy_clause(int id) {
+        super(id);
+    }
+
+    public ASTrow_deletion_policy_clause(DdlParser p, int id) {
+        super(p, id);
+    }
+
+    @Override
+    public String toString() {
+        // eg ROW DELETION POLICY (OLDER_THAN(ExpiredDate, INTERVAL 0 DAY));
+        return String.format("ROW DELETION POLICY (%s)", ((ASTrow_deletion_policy_expression) children[0]));
+    }
+}

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTrow_deletion_policy_column.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTrow_deletion_policy_column.java
@@ -1,0 +1,26 @@
+
+package com.google.cloud.solutions.spannerddl.parser;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.google.common.base.Joiner;
+import java.util.Arrays;
+
+
+/** Abstract Syntax Tree parser object for "row_deletion_policy_column" token */
+public class ASTrow_deletion_policy_column extends SimpleNode {
+    private static final Logger LOG = LoggerFactory.getLogger(ASTrow_deletion_policy_column.class);
+
+    public ASTrow_deletion_policy_column(int id) {
+        super(id);
+    }
+
+    public ASTrow_deletion_policy_column(DdlParser p, int id) {
+        super(p, id);
+    }
+
+    @Override
+    public String toString() {
+        return jjtGetFirstToken().toString();
+    }
+}

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTrow_deletion_policy_expression.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTrow_deletion_policy_expression.java
@@ -1,0 +1,39 @@
+
+package com.google.cloud.solutions.spannerddl.parser;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.google.common.base.Joiner;
+import java.util.Arrays;
+
+
+// TODO Support row deletion policy clause in ALTER statements
+/** Abstract Syntax Tree parser object for "row_deletion_policy_expression" token */
+public class ASTrow_deletion_policy_expression extends SimpleNode {
+    private static final Logger LOG = LoggerFactory.getLogger(ASTrow_deletion_policy_expression.class);
+
+    public ASTrow_deletion_policy_expression(int id) {
+        super(id);
+    }
+
+    public ASTrow_deletion_policy_expression(DdlParser p, int id) {
+        super(p, id);
+    }
+
+    private String getRdpFunction() {
+        return ((ASTrow_deletion_policy_function) children[0]).toString();
+    }
+
+    private String getRdpColumn() {
+        return ((ASTrow_deletion_policy_column) children[1]).toString();
+    }
+
+    private String getRdpIntervalExpr() {
+        return ((ASTinterval_expression) children[2]).toString();
+    }
+    @Override
+    public String toString() {
+        // eg OLDER_THAN(ExpiredDate, INTERVAL 0 DAY);
+        return String.format("%s(%s, %s)", getRdpFunction(), getRdpColumn(), getRdpIntervalExpr());
+    }
+}

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTrow_deletion_policy_function.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTrow_deletion_policy_function.java
@@ -1,0 +1,27 @@
+
+package com.google.cloud.solutions.spannerddl.parser;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.google.common.base.Joiner;
+import java.util.Arrays;
+
+
+/** Abstract Syntax Tree parser object for "row_deletion_policy_function" token */
+public class ASTrow_deletion_policy_function extends SimpleNode {
+    private static final Logger LOG = LoggerFactory.getLogger(ASTrow_deletion_policy_function.class);
+
+    public ASTrow_deletion_policy_function(int id) {
+        super(id);
+    }
+
+    public ASTrow_deletion_policy_function(DdlParser p, int id) {
+        super(p, id);
+    }
+
+    @Override
+    public String toString() {
+        // e.g. OLDER THAN
+        return jjtGetFirstToken().toString();
+    }
+}

--- a/src/main/jjtree-sources/ddl_keywords.jjt
+++ b/src/main/jjtree-sources/ddl_keywords.jjt
@@ -1,18 +1,3 @@
-//
-// Copyright 2020 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
 
 TOKEN:
 {
@@ -126,7 +111,9 @@ TOKEN:
   | <CONSTRAINT:               "constraint">
   | <DATABASE:                 "database">
   | <DATE:                     "date">
+  | <DAY:                      "day">
   | <DELETE:                   "delete">
+  | <DELETION:                 "deletion">
   | <DROP:                     "drop">
   | <FLOAT64:                  "float64">
   | <FOREIGN:                  "foreign">
@@ -140,8 +127,11 @@ TOKEN:
   | <NUMERIC:                  "numeric">
   | <OPTIONS:                  "options">
   | <PARENT:                   "parent">
+  | <POLICY:                   "policy">
   | <PRIMARY:                  "primary">
   | <REFERENCES:               "references">
+  | <REPLACE:                  "replace">
+  | <ROW:                      "row">
   | <STORED:                   "stored">
   | <STORING:                  "storing">
   | <STRING:                   "string">
@@ -164,7 +154,9 @@ void pseudoReservedWord() #void :
   | <CONSTRAINT>
   | <DATABASE>
   | <DATE>
+  | <DAY>
   | <DELETE>
+  | <DELETION>
   | <DROP>
   | <FLOAT64>
   | <FOREIGN>
@@ -178,8 +170,11 @@ void pseudoReservedWord() #void :
   | <NUMERIC>
   | <OPTIONS>
   | <PARENT>
+  | <POLICY>
   | <PRIMARY>
   | <REFERENCES>
+  | <REPLACE>
+  | <ROW>
   | <STORED>
   | <STORING>
   | <STRING>

--- a/src/main/jjtree-sources/ddl_parser.jjt
+++ b/src/main/jjtree-sources/ddl_parser.jjt
@@ -100,6 +100,7 @@ void create_table_statement() :
   "(" [ table_element() ( LOOKAHEAD(2) "," table_element() )* [ "," ] ] ")"
   primary_key()
   [ LOOKAHEAD(2) "," table_interleave_clause() ]
+  [ LOOKAHEAD(2) "," row_deletion_policy_clause() ]
 }
 
 void table_element() #void :
@@ -197,6 +198,25 @@ void table_interleave_clause() :
 {
   <INTERLEAVE> <IN> <PARENT> identifier() #interleave_in
     [ on_delete_clause() ]
+}
+
+void row_deletion_policy_clause():
+{}
+{
+  <ROW> <DELETION> <POLICY> "(" row_deletion_policy_expression() ")"
+}
+
+void row_deletion_policy_expression():
+{}
+{
+  identifier() #row_deletion_policy_function
+  "(" identifier() #row_deletion_policy_column "," interval_expression() ")"
+}
+
+void interval_expression():
+{}
+{
+  <INTERVAL> int_value() <DAY>
 }
 
 void on_delete_clause() :
@@ -306,12 +326,16 @@ void alter_table_statement() :
   (   LOOKAHEAD(3) <ADD> #add_column [LOOKAHEAD(2) <COLUMN>] column_def()
     | LOOKAHEAD(3) <DROP> <CONSTRAINT> #drop_constraint
         identifier() #constraint_name
-    | <DROP> #drop_column [LOOKAHEAD(2) <COLUMN>] (identifier() #column_name)
+    | LOOKAHEAD(3) <DROP> <ROW> <DELETION> <POLICY> #drop_row_deletion_policy
+    | LOOKAHEAD(3) <DROP> #drop_column [LOOKAHEAD(2) <COLUMN>] (identifier() #column_name)
+    | LOOKAHEAD(3) <DROP> <ROW> <DELETION> <POLICY> #drop_row_deletion_policy
     | LOOKAHEAD(3) <ALTER> #alter_column [LOOKAHEAD(2) <COLUMN>]
         (identifier() #name) column_def_alter()
     | <SET> #set_on_delete on_delete_clause()
     | LOOKAHEAD(4) <ADD> foreign_key()
-    | <ADD> check_constraint()
+    | LOOKAHEAD(2) <ADD> check_constraint()
+    | LOOKAHEAD(2) <ADD> row_deletion_policy_clause() #add_row_deletion_policy
+    | <REPLACE> row_deletion_policy_clause() #replace_row_deletion_policy
   )
 }
 


### PR DESCRIPTION
- Sync with JJT defs with latest Spanner emulator
- Add parser logic for `ROW DELETION POLICY` tokens
- Add support to naively regenerate `ROW DELETION POLICY` expressions
  - Notably, support for such `ALTER TABLE` statements is likely not there

No tests yolo