### PR TITLE
Support modifications in ROW DELETION POLICY clause

### DIFF
--- a/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
@@ -286,7 +286,7 @@ public class DdlDiff {
       throw new DdlDiffException("Cannot change primary key of table " + left.getTableName());
     }
 
-    // On delete changed
+    // On delete changed for interleave clause
     if (left.getInterleaveClause().isPresent()
         && !(left.getInterleaveClause()
         .get()
@@ -297,6 +297,38 @@ public class DdlDiff {
               + left.getTableName()
               + " SET "
               + right.getInterleaveClause().get().getOnDelete());
+    }
+
+    // Row Deletion Policy - Modified
+    // TODO add support for ALTER TABLE statements too, deduped like fkey statements.
+    if (left.getRowDeletionPolicyClause().isPresent()
+        && right.getRowDeletionPolicyClause().isPresent()
+        && !(left.getRowDeletionPolicyClause().get()
+             .equals(right.getRowDeletionPolicyClause().get()))) {
+        alterStatements.add(
+                            "ALTER TABLE "
+                            + left.getTableName()
+                            + " REPLACE "
+                            + right.getRowDeletionPolicyClause().get());
+    }
+
+    // Row Deletion Policy - Dropped
+    if (left.getRowDeletionPolicyClause().isPresent()
+        && !right.getRowDeletionPolicyClause().isPresent()) {
+        alterStatements.add(
+                            "ALTER TABLE "
+                            + left.getTableName()
+                            + " DROP ROW DELETION POLICY");
+    }
+
+    // Row Deletion Policy - Added
+    if (!left.getRowDeletionPolicyClause().isPresent()
+        && right.getRowDeletionPolicyClause().isPresent()) {
+        alterStatements.add(
+                            "ALTER TABLE "
+                            + left.getTableName()
+                            + " ADD "
+                            +right.getRowDeletionPolicyClause().get());
     }
 
     // compare columns.

--- a/src/test/resources/expectedDdlDiff.txt
+++ b/src/test/resources/expectedDdlDiff.txt
@@ -151,5 +151,18 @@ ALTER TABLE test_fkey ADD CONSTRAINT fk_col1 FOREIGN KEY (col1) REFERENCES test1
 
 == TEST 25 move foreign key out of create table
 # No change
+
+== TEST 26 create table with row deletion policy
+# No change
+
+
+== TEST 27 drop row deletion policy
+
+ALTER TABLE test_rdp DROP ROW DELETION POLICY
+
+== TEST 28 modify row deletion policy
+
+ALTER TABLE test_rdp REPLACE ROW DELETION POLICY (older_than(created_at, INTERVAL 99 DAY))
+
 ==
 

--- a/src/test/resources/newDdl.txt
+++ b/src/test/resources/newDdl.txt
@@ -238,5 +238,29 @@ create table test1 (
 primary key (col1);
 alter table test1 add constraint fk_in_table foreign key (col1) references othertable(othercol1)
 
+== TEST 26 create table with row deletion policy
+
+create table test_rdp (
+  col1 int64,
+  col2 int64,
+  created_at timestamp,
+) primary key (col1), row deletion policy (older_than(created_at, interval 2 DAY));
+
+== TEST 27 drop row deletion policy
+
+create table test_rdp (
+  col1 int64,
+  col2 int64,
+  created_at timestamp,
+) primary key (col1);
+
+== TEST 28 modify row deletion policy
+
+create table test_rdp (
+  col1 int64,
+  col2 int64,
+  created_at timestamp,
+) primary key (col1), row deletion policy (older_than(created_at, interval 99 DAY));
+
 ==
 

--- a/src/test/resources/originalDdl.txt
+++ b/src/test/resources/originalDdl.txt
@@ -241,6 +241,30 @@ create table test1 (
 )
 primary key (col1);
 
+== TEST 26 create table with row deletion policy
+
+create table test_rdp (
+  col1 int64,
+  col2 int64,
+  created_at timestamp,
+) primary key (col1), row deletion policy (older_than(created_at, interval 2 DAY));
+
+== TEST 27 drop row deletion policy
+
+create table test_rdp (
+  col1 int64,
+  col2 int64,
+  created_at timestamp,
+) primary key (col1), row deletion policy (older_than(created_at, interval 2 DAY));
+
+== TEST 28 modify row deletion policy
+
+create table test_rdp (
+  col1 int64,
+  col2 int64,
+  created_at timestamp,
+) primary key (col1), row deletion policy (older_than(created_at, interval 2 DAY));
+
 ==
 
 


### PR DESCRIPTION
Support dropping / replacing row deletion policy

Note: Only works for CREATE TABLE statements. Probably never adding support for ALTER TABLE statements :new_moon_with_face: 